### PR TITLE
Mon sprint 7/mon 218

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -88,6 +88,7 @@ import errors from './features/errors';
 import users from './features/log/users';
 import profile from './features/profile';
 import errorDetails from './features/errors/error-details';
+import errorInfo from './features/errors/error-info';
 
 //custom css
 import './features/styles/index.styl';
@@ -152,7 +153,8 @@ angular.module('app', [
 	errorAggregate,
 	errorRecent,
 	profile,
-	errorDetails
+	errorDetails,
+	errorInfo
 
 ]).constant('EVENTS', {})
 	.config(routing)

--- a/client/src/features/errors/error-details/error-details.html
+++ b/client/src/features/errors/error-details/error-details.html
@@ -88,6 +88,16 @@
 				</div>
 
 			</div>
+			<div class="row" id="detailsss">
+				<div class="col-md-6 col-xs-12">
+					<div class="detail-group">
+						<span class="detail-group-label">Error persistent link</span>
+						<span class="detail-group-value">
+							<a target="_blank" ng-href="/log/{{::ctrl.error.log.logId}}/{{::ctrl.error.guid}}">{{::ctrl.error.guid}}</a>
+						</span>
+					</div>
+				</div>
+			</div>
 			<div class="row stacktrace" ng-if="ctrl.error.detail">
 				<div hljs-language="accesslog" hljs hljs-no-escape hljs-source="ctrl.error.detail">
 				</div>

--- a/client/src/features/errors/error-info/error-info.controller.js
+++ b/client/src/features/errors/error-info/error-info.controller.js
@@ -1,0 +1,24 @@
+
+export default class ErrorInfoController {
+	static get $inject() {
+		return ['$scope', '$stateParams', '$q', 'logs', 'loaderService'];
+	}
+
+	constructor($scope, $stateParams, $q, logService, loaderService) {
+		this.$q = $q;
+		this.$scope = $scope;
+		this.logService = logService;
+		this.loaderService = loaderService;
+
+		this.logId = $stateParams.id;
+		this.errorId = $stateParams.errorId;
+		$scope.haveToRequestErrorInfo = $stateParams.errorId !== undefined && $stateParams.errorId !== '' && $stateParams.errorId !== 'settings';
+		if ($scope.haveToRequestErrorInfo) {
+			$scope.getErrorInfoPromise = this.logService.getError(this.errorId);
+		}
+	}
+
+	$onInit() {
+
+	}
+}

--- a/client/src/features/errors/error-info/error-info.html
+++ b/client/src/features/errors/error-info/error-info.html
@@ -1,0 +1,2 @@
+<div id="errorInfoContainer"></div>
+

--- a/client/src/features/errors/error-info/error-info.js
+++ b/client/src/features/errors/error-info/error-info.js
@@ -1,0 +1,34 @@
+import $ from 'jquery';
+import angular from 'angular';
+import errorInfoHtml from './error-info.html';
+import controller from './error-info.controller';
+export default ErrorInfo;
+
+ErrorInfo.$inject = ['$compile', '$rootScope'];
+
+function ErrorInfo($compile, $rootScope) {
+	return {
+		restrict: 'E',
+		scope: {},
+		template: errorInfoHtml,
+		controller: controller,
+		controllerAs: 'ctrl',
+		bindToController: {
+		},
+		link: function (scope, elem, attrs) {
+
+			if (scope.haveToRequestErrorInfo) {
+				scope.getErrorInfoPromise.then((result) => {
+					let mainDiv = $('#errorInfoContainer');
+					let errorDetailsComp = angular.element('<error-details error="error"></error-details>');
+					let newScope = scope.$new(true);
+					newScope.error = result.data;
+					let html = $compile(errorDetailsComp)(newScope);
+					mainDiv.append(html);
+
+					$rootScope.$emit('openErrorInfo');
+				});
+			}
+		}
+	};
+}

--- a/client/src/features/errors/error-info/index.js
+++ b/client/src/features/errors/error-info/index.js
@@ -1,0 +1,9 @@
+import './error-info.styl';
+
+import angular from 'angular';
+
+import component from './error-info';
+
+export default angular.module('ErrorInfo', [])
+	.directive('errorInfo', component)
+	.name;

--- a/client/src/features/log/log.controller.js
+++ b/client/src/features/log/log.controller.js
@@ -9,15 +9,22 @@ export default class LogController {
 		this.$window = $window;
 		this.logService = logService;
 		this.logId = $stateParams.id;
+		this.errorId = $stateParams.errorId;
 		this.tableOptions = {
 			LogId: $stateParams.id
 		};
 		this.logName = '';
+		this.showErrorTab = this.errorId !== undefined && this.errorId !== '' && this.errorId !== 'settings';
+		this.errorInfo = {};
 	}
 
 	$onInit() {
 		this.$rootScope.$on('openErrorDetails', () => {
 			this.switchToErrorTab();
+		});
+
+		this.$rootScope.$on('openErrorInfo', () => {
+			this.switchToErrorInfoTab();
 		});
 
 		this.$scope.$on('errorTableFilterUpdate', () => {
@@ -31,5 +38,9 @@ export default class LogController {
 
 	switchToErrorTab() {
 		this.$window.$('.nav a[data-target="#errors"]').tab('show');
+	}
+
+	switchToErrorInfoTab() {
+		this.$window.$('.nav a[data-target="#errorInfo"]').tab('show');
 	}
 }

--- a/client/src/features/log/log.html
+++ b/client/src/features/log/log.html
@@ -21,6 +21,7 @@
 					<ul class="nav nav-tabs">
 						<li class="active pointer"><a data-target="#overview" data-toggle="tab">Overview</a></li>
 						<li class="pointer"><a data-target="#errors" data-toggle="tab">Errors</a></li>
+						<li class="pointer" ng-if="ctrl.showErrorTab"><a data-target="#errorInfo" data-toggle="tab">Error Details</a></li>
 					</ul>
 					<div class="tab-content">
 						<div class="active tab-pane" id="overview">
@@ -29,6 +30,11 @@
 						<!-- /.tab-pane -->
 						<div class="tab-pane" id="errors">
 							<errors settings="ctrl.tableOptions"></errors>
+						</div>
+						<!-- /.tab-pane -->
+						<!-- /.tab-pane -->
+						<div class="tab-pane" id="errorInfo">
+							<error-info errorId="ctrl.errorId"></error-info>
 						</div>
 						<!-- /.tab-pane -->
 					</div>

--- a/client/src/features/log/log.routes.js
+++ b/client/src/features/log/log.routes.js
@@ -2,7 +2,7 @@ routes.$inject = ['$stateProvider'];
 
 export default function routes($stateProvider) {
 	$stateProvider.state('main.log', {
-		url: 'log/:id',
+		url: 'log/:id/:errorId',
 		parent: 'main',
 		template: '<log></log>'
 	}).state('main.log.settings', {

--- a/client/src/features/services/logs.js
+++ b/client/src/features/services/logs.js
@@ -87,6 +87,12 @@ export default class Logs {
 		return this.httpService.getJson(request);
 	}
 
+	getError(errorId) {
+		let request = {
+			url: '/errors/' + errorId + '/info'
+		};
+		return this.httpService.getJson(request);
+	}
 
 	getLog(logId) {
 		let request = {

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -12,16 +12,18 @@ module.exports = webpackMerge.smart(commonConfig, {
 		new webpack.HotModuleReplacementPlugin(),
 		new webpack.DefinePlugin({
 			AUTH_REDIRECTURL: '\'http://localhost:8000/login\'',
-			AUTH0_CLIENT_ID: '\'2YUcbwH2ypc7LZ56HscwhJmgAy6UOeVb\'',
-			AUTH0_DOMAIN: '\'greystatsllc.auth0.com\'',
+			/*AUTH0_CLIENT_ID: '\'2YUcbwH2ypc7LZ56HscwhJmgAy6UOeVb\'',*/
+			AUTH0_CLIENT_ID: '\'bETIoIcsKnZHShZh2kKXVCFOHmVKSU52\'',
+			AUTH0_DOMAIN: '\'ksbrov.auth0.com\'',
 			BASE_API: '\'http://localhost:18000/api\'',
-			AUTH0_SIGNUP_URL: '\'https://greystatsllc.auth0.com/dbconnections/signup\'',
+			AUTH0_SIGNUP_URL: '\'https://ksbrov.auth0.com/dbconnections/signup\'',
+			/*AUTH0_SIGNUP_URL: '\'https://greystatsllc.auth0.com/dbconnections/signup\'',*/
 			AUTH0_DB_CONNECTION:'\'Username-Password-Authentication\''
 		}),
 		new webpack.DefinePlugin({
 			'process.env': {
 				'NODE_ENV': JSON.stringify('dev'),
-				'API_URL': JSON.stringify('http://localhost:8000/api')
+				'API_URL': JSON.stringify('http://localhost:18000/api')
 			}
 		})
 	],

--- a/deploy/production-application-run.sh
+++ b/deploy/production-application-run.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-NODE_ENV=production pm2 start --name "production-admin" /home/bitnami/apps/admin.elmahbucket.io/server/server.js
+NODE_ENV=production pm2 start --name "production-admin" /home/bitnami/apps/admin.monitorr.io/server/server.js
 pm2 save

--- a/deploy/staging-application-run.sh
+++ b/deploy/staging-application-run.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-NODE_ENV=staging pm2 start --name "staging-admin" /home/bitnami/apps/staging-admin.elmahbucket.io/server/server.js
+NODE_ENV=staging pm2 start --name "staging-admin" /home/bitnami/apps/staging-admin.monitorr.io/server/server.js
 pm2 save


### PR DESCRIPTION
Added separated tab for displaying "error info" 
The "Error persistent link" was added to error "Details" tab as well:

![image](https://user-images.githubusercontent.com/32640924/32148307-f169d9c4-bd05-11e7-953c-0a80301b210b.png)
